### PR TITLE
search for system variables the Maestro URL if defined, if it returns…

### DIFF
--- a/app/configurations.py
+++ b/app/configurations.py
@@ -4,3 +4,4 @@ import os
 MAESTRO_KEY = os.getenv("MAESTRO_KEY")
 MAESTRO_LOGIN = os.getenv("MAESTRO_LOGIN")
 MAESTRO_WORKSPACE = os.getenv("MAESTRO_WORKSPACE")
+MAESTRO_URL = os.getenv("MAESTRO_URL") or "https://developers.botcity.dev"

--- a/data_source/botcity.py
+++ b/data_source/botcity.py
@@ -7,7 +7,7 @@ from app import configurations as config
 
 class BotcityApiPlugin:
 
-    API_URL = 'https://developers.botcity.dev/api/v2'
+    API_URL = f'{config.MAESTRO_URL}/api/v2'
     TOKEN_EXPIRATION_TIME = 3600
 
     def __init__(self, login: str, key: str):


### PR DESCRIPTION
search for system variables the Maestro URL if defined, if it returns none it uses the default value (https://developers.botcity.dev)

Closes #5 